### PR TITLE
Add server code by PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,26 @@ npm i
 npm start
 ```
 
+### PHPサーバー
+
+server/on-cloud-run-functions/phpディレクトリに移動して、[Composer](https://getcomposer.org/) で依存ライブラリをインストールしてください。
+次に、環境変数 `APP_ID` と `SECRET_KEY`、 `VALID_FIXED_SESSION_TOKEN` に値を設定してください。
+- `APP_ID` と `SECRET_KEY`は、それぞれ自身のApp ID、Secret Keyを設定してください。
+- `VALID_FIXED_SESSION_TOKEN`は、クライアントアプリケーションを検証する際に用いる固定値を設定してください。
+  - 後述のクライアントアプリケーションをそのまま使う場合は、[`4CXS0f19nvMJBYK05o3toTWtZF5Lfd2t6Ikr2lID`](https://github.com/skyway/authentication-samples/blob/ea675724d7458c0f765b018c1698980493f8b06b/client/index.js#L15)を設定してください。
+  - サンプルのため、クライアントアプリケーションからの[リクエストボディの sessionToken パラメーター](https://github.com/skyway/authentication-samples/blob/ea675724d7458c0f765b018c1698980493f8b06b/client/index.js#L15)と比較で検証する作りにしています。本番環境では、より高度な検証方法を用いられることが望ましいです。
+
+環境変数の設定ができない場合は、 .env.example ファイルの名前を .env に変更し、上記3変数に値を設定してファイルを保存してください。
+その後、環境変数`FUNCTION_TARGET`を設定し、`php -S localhost:8080` コマンドでローカルサーバーを起動してください。
+サーバーは8080ポートを使用します。
+
+```sh
+cd server/on-cloud-run-functions/php
+composer install
+
+FUNCTION_TARGET=main php -S localhost:8080 vendor/google/cloud-functions-framework/router.php
+```
+
 ## クライアントアプリケーション
 
 サーバーアプリケーションにリクエストを行い、認証情報を取得します。

--- a/server/on-cloud-run-functions/php/.env.example
+++ b/server/on-cloud-run-functions/php/.env.example
@@ -1,0 +1,4 @@
+# get from https://console.skyway.ntt.com/
+APP_ID=
+SECRET_KEY=
+VALID_FIXED_SESSION_TOKEN=

--- a/server/on-cloud-run-functions/php/.gitignore
+++ b/server/on-cloud-run-functions/php/.gitignore
@@ -1,0 +1,6 @@
+# Composer dependencies
+vendor/
+composer.lock
+
+# dotenv files
+.env

--- a/server/on-cloud-run-functions/php/composer.json
+++ b/server/on-cloud-run-functions/php/composer.json
@@ -1,0 +1,8 @@
+{
+    "require": {
+        "firebase/php-jwt": "^6.11.0",
+        "ramsey/uuid": "^4.7.6",
+        "google/cloud-functions-framework": "^1.4",
+        "vlucas/phpdotenv": "^5.6"
+    }
+}

--- a/server/on-cloud-run-functions/php/index.php
+++ b/server/on-cloud-run-functions/php/index.php
@@ -1,0 +1,127 @@
+<?php
+use Google\CloudFunctions\FunctionsFramework;
+use Psr\Http\Message\ServerRequestInterface;
+use Firebase\JWT\JWT;
+use Ramsey\Uuid\Uuid;
+require 'vendor/autoload.php';
+
+// load environment variables from .env file
+// - createImmutable() prevents overriding existing environment variables
+// - safeLoad() continues execution even if .env file doesn't exist
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
+$dotenv->safeLoad();
+
+// should set your appId and secret key in `environment variable` or in `.env file`
+$appId = getenv('APP_ID') ?: $_ENV['APP_ID'] ?: 'YourAppId (Deprecated)';
+$secretKey = getenv('SECRET_KEY') ?: $_ENV['SECRET_KEY'] ?: 'YourSecretKey (Deprecated)';
+$validFixedSessionToken = getenv('VALID_FIXED_SESSION_TOKEN') ?: $_ENV['VALID_FIXED_SESSION_TOKEN'] ?: 'YourValidFixedSessionToken (Deprecated)';
+
+function authenticate($request) {
+    global $validFixedSessionToken;
+
+    $roomName = $request['roomName'] ?? null;
+    $memberName = $request['memberName'] ?? null;
+    $sessionToken = $request['sessionToken'] ?? null;
+
+    if ($roomName === null || $memberName === null || $sessionToken === null) {
+        http_response_code(400);
+        echo 'Bad Request';
+        return;
+    }
+
+    // Check the sessionToken for your app.
+    if ($sessionToken !== $validFixedSessionToken) {
+        http_response_code(401);
+        echo 'Authentication Failed';
+        return;
+    }
+
+    $iat = time();
+    $exp = $iat + 36000; // 10h
+
+    $credential = [
+        'roomName' => $roomName,
+        'memberName' => $memberName,
+        'iat' => $iat,
+        'exp' => $exp,
+        'authToken' => calculateAuthToken($roomName, $memberName, $iat, $exp)
+    ];
+
+    return json_encode($credential);
+}
+
+function calculateAuthToken($roomName, $memberName, $iat, $exp) {
+    global $appId, $secretKey;
+
+    $payload = [
+        'jti' => Uuid::uuid4()->toString(),
+        'iat' => $iat,
+        'exp' => $exp,
+        'version' => 3,
+        'scope' => [
+            'appId' => $appId,
+            'turn' => [
+                'enabled' => true
+            ],
+            'analytics' => [
+                'enabled' => true
+            ],
+            'rooms' => [
+                [
+                    'id' => '*',
+                    'name' => $roomName,
+                    'methods' => ['create', 'close', 'updateMetadata'],
+                    'sfu' => [
+                        'enabled' => true,
+                        'maxSubscribersLimit' => 99
+                    ],
+                    'member' => [
+                        'id' => '*',
+                        'name' => $memberName,
+                        'methods' => ['publish', 'subscribe', 'updateMetadata']
+                    ]
+                ]
+            ]
+        ]
+    ];
+
+    return JWT::encode($payload, $secretKey, 'HS256');
+}
+
+// Register the function with Functions Framework.
+// This enables omitting the `FUNCTIONS_SIGNATURE_TYPE=http` environment
+// variable when deploying. The `FUNCTION_TARGET` environment variable should
+// match the first parameter.
+FunctionsFramework::http('main', 'main');
+
+function main(ServerRequestInterface $request): string
+{
+    header('Access-Control-Allow-Origin: *');
+    header('Access-Control-Allow-Headers: Origin, X-Requested-With, Content-Type, Accept');
+
+    $requestMethod = $_SERVER['REQUEST_METHOD'];
+    $requestPath = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+
+    if ($requestPath === '/authenticate' && $requestMethod === 'POST') {
+        $contentType = $_SERVER['CONTENT_TYPE'] ?? '';
+        if ($contentType === 'application/json') {
+            $requestBody = file_get_contents('php://input');
+            $request = json_decode($requestBody, true);
+        } else {
+            $request = $_POST;
+        }
+
+        return authenticate($request);
+    }
+
+    if ($requestMethod === 'OPTIONS') {
+        // Preflight request
+        header('Access-Control-Allow-Methods: POST, OPTIONS');
+        http_response_code(204);
+        return '';
+    }
+
+    http_response_code(404);
+    return 'Not Found';
+}
+?>


### PR DESCRIPTION
### 変更点
- `server/on-cloud-run-functions/php` を新設し、以下のPHPでのSkyWay Auth Token払い出しのコードサンプルを配置しています。
  - `index.php`: 払い出しコードのメインファイル
  - `.env.example`: .envファイルのサンプル
  - `composer.json`: 必要なPHPパッケージを追加（`firebase/php-jwt`, `ramsey/uuid`, `google/cloud-functions-framework`
  - `.gitignore`: Composerの依存関係とロックファイル、.envファイルを無視するように設定
- READMEの更新

### by Copilot
This pull request introduces a new PHP server setup for handling authentication in the `server/on-cloud-run-functions/php` directory. The changes include updates to the `README.md` file, configuration files, and the addition of necessary dependencies and server logic.

### Server implementation:
* [`server/on-cloud-run-functions/php/index.php`](diffhunk://#diff-79236aeb76c0b9c082785b2d6a8d1c073b575429b06ade503013d398174c3134R1-R127): Added the main PHP script to handle authentication requests, load environment variables, and define the authentication logic using JWT and UUID libraries.

### Configuration files:
* [`server/on-cloud-run-functions/php/.env.example`](diffhunk://#diff-6c8b6558d3da837894f38a61d98cccf50b2795bd6b6c5c0e25b5394310e565d8R1-R4): Added example environment variables for `APP_ID`, `SECRET_KEY`, and `VALID_FIXED_SESSION_TOKEN`.
* [`server/on-cloud-run-functions/php/.gitignore`](diffhunk://#diff-3672341a32b53efbfcf2ed55f28404421a2843a311401fe79b3d6278235b52f8R1-R6): Added entries to ignore Composer dependencies and dotenv files.

### Dependencies:
* [`server/on-cloud-run-functions/php/composer.json`](diffhunk://#diff-3ff95af81225f824132fe2d55509dcaec90fbc1db842839835d2610ac70d0a6cR1-R8): Added required PHP packages including `firebase/php-jwt`, `ramsey/uuid`, `google/cloud-functions-framework`, and `vlucas/phpdotenv`.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R24-R43): Added instructions for setting up the PHP server, including installing dependencies with Composer and setting environment variables.
